### PR TITLE
When parsing sample rate the server crashes

### DIFF
--- a/src/statsd.c
+++ b/src/statsd.c
@@ -673,7 +673,7 @@ void process_stats_packet(char buf_in[]) {
       } else {
         /* Handle non-timer, as counter */
         if (s_sample_rate && *s_sample_rate == '@') {
-          sample_rate = strtod( (char *) *(s_sample_rate + 1), (char **) NULL );
+          sample_rate = strtod( (s_sample_rate + 1), (char **) NULL );
         }
         update_counter(key_name, value, sample_rate);
         syslog(LOG_DEBUG, "Found key name '%s'\n", key_name);


### PR DESCRIPTION
Program received signal EXC_BAD_ACCESS, Could not access memory.
Reason: KERN_INVALID_ADDRESS at address: 0x0000000000000030
[Switching to process 67598 thread 0x1703]
0x00007fff8abf9e6c in strtod_l ()
(gdb) bt
#0  0x00007fff8abf9e6c in strtod_l ()
#1  0x000000010000a8d8 in process_stats_packet (buf_in=0x100b86af0 "mynamespace.count3") at statsd.c:676
#2  0x000000010000b29f in p_thread_queue (ptr=0x7fff5fbff834) at statsd.c:791
#3  0x00007fff8ac0d8bf in _pthread_start ()
#4  0x00007fff8ac10b75 in thread_start ()

(gdb) up
#1  0x000000010000a8d8 in process_stats_packet (buf_in=0x100b86af0 "mynamespace.count3") at statsd.c:676

676               sample_rate = strtod( (char _) *(s_sample_rate + 1), (char *_) NULL );
(gdb) p s_sample_rate
$1 = 0x100901580 "@0.80"

It seems that this casting is invalid.

P.S. For some reason on MacOS X the HAVE_VASPRINTF macro is not set to 1, therefor the compilation fails on src/json-c/printbuf.c
